### PR TITLE
Run lint-staged from local node_modules, not global

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpx lint-staged
+pnpm exec lint-staged


### PR DESCRIPTION
In a different repo, I had some errors with mismatched node versions. The repo used 20.16, but my locally installed lint-staged requires 20.17+.

Since this repo uses node 22, there is no acute problem, but in general you should not rely on or use globally-installed packages.