### PR TITLE
Side Navigation Consistency

### DIFF
--- a/packages/storybook/src/templates/mijn-omgeving-basis/mijn-omgeving-basis.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-basis/mijn-omgeving-basis.stories.tsx
@@ -20,6 +20,7 @@ import {
   IconHome,
   IconInbox,
   IconLayoutGrid,
+  IconListCheck,
   IconParking,
   IconUser,
 } from '@tabler/icons-react';
@@ -78,14 +79,20 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
           <SideNavigationList>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
+                <IconListCheck />
+                Mijn taken
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#">
                 <IconInbox />
-                Berichten <NumberBadge>2</NumberBadge>
+                Mijn berichten <NumberBadge>2</NumberBadge>
               </SideNavigationLink>
             </SideNavigationItem>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconArchive />
-                Lopende zaken
+                Mijn zaken
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>
@@ -119,7 +126,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconUser />
-                Gegevens
+                Mijn gegevens
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-berichten-overzicht/mijn-omgeving.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-berichten-overzicht/mijn-omgeving.stories.tsx
@@ -20,6 +20,7 @@ import {
   IconHome,
   IconInbox,
   IconLayoutGrid,
+  IconListCheck,
   IconParking,
   IconUser,
 } from '@tabler/icons-react';
@@ -75,7 +76,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
         <SideNavigationBase>
           <SideNavigationList>
             <SideNavigationItem>
-              <SideNavigationLink href="/#" current>
+              <SideNavigationLink href="/#">
                 <IconLayoutGrid />
                 Overzicht
               </SideNavigationLink>
@@ -84,14 +85,20 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
           <SideNavigationList>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
+                <IconListCheck />
+                Mijn taken
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#" current>
                 <IconInbox />
-                Berichten <NumberBadge>2</NumberBadge>
+                Mijn berichten <NumberBadge>2</NumberBadge>
               </SideNavigationLink>
             </SideNavigationItem>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconArchive />
-                Lopende zaken
+                Mijn zaken
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>
@@ -125,7 +132,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconUser />
-                Gegevens
+                Mijn gegevens
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-home/mijn-omgeving.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-home/mijn-omgeving.stories.tsx
@@ -25,6 +25,7 @@ import {
   IconInbox,
   IconInfoCircle,
   IconLayoutGrid,
+  IconListCheck,
   IconParking,
   IconUser,
 } from '@tabler/icons-react';
@@ -90,14 +91,20 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
           <SideNavigationList>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
+                <IconListCheck />
+                Mijn taken
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#">
                 <IconInbox />
-                Berichten<NumberBadge>2</NumberBadge>
+                Mijn berichten <NumberBadge>2</NumberBadge>
               </SideNavigationLink>
             </SideNavigationItem>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconArchive />
-                Lopende zaken
+                Mijn zaken
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>
@@ -131,7 +138,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconUser />
-                Gegevens
+                Mijn gegevens
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-taken-overzicht/mijn-omgeving.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-taken-overzicht/mijn-omgeving.stories.tsx
@@ -20,6 +20,7 @@ import {
   IconHome,
   IconInbox,
   IconLayoutGrid,
+  IconListCheck,
   IconParking,
   IconUser,
 } from '@tabler/icons-react';
@@ -76,7 +77,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
         <SideNavigationBase>
           <SideNavigationList>
             <SideNavigationItem>
-              <SideNavigationLink href="/#" current>
+              <SideNavigationLink href="/#">
                 <IconLayoutGrid />
                 Overzicht
               </SideNavigationLink>
@@ -84,15 +85,21 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
           </SideNavigationList>
           <SideNavigationList>
             <SideNavigationItem>
+              <SideNavigationLink href="/#" current>
+                <IconListCheck />
+                Mijn taken
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconInbox />
-                Berichten <NumberBadge>2</NumberBadge>
+                Mijn berichten <NumberBadge>2</NumberBadge>
               </SideNavigationLink>
             </SideNavigationItem>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconArchive />
-                Lopende zaken
+                Mijn zaken
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>
@@ -126,7 +133,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconUser />
-                Gegevens
+                Mijn gegevens
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-zaakdetail/mijn-omgeving-zaakdetail.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaakdetail/mijn-omgeving-zaakdetail.stories.tsx
@@ -23,6 +23,7 @@ import {
   IconHome,
   IconInbox,
   IconLayoutGrid,
+  IconListCheck,
   IconParking,
   IconUser,
 } from '@tabler/icons-react';
@@ -79,7 +80,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
         <SideNavigationBase>
           <SideNavigationList>
             <SideNavigationItem>
-              <SideNavigationLink href="/#" current>
+              <SideNavigationLink href="/#">
                 <IconLayoutGrid />
                 Overzicht
               </SideNavigationLink>
@@ -88,14 +89,20 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
           <SideNavigationList>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
-                <IconInbox />
-                Berichten<NumberBadge>2</NumberBadge>
+                <IconListCheck />
+                Mijn taken
               </SideNavigationLink>
             </SideNavigationItem>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
+                <IconInbox />
+                Mijn berichten <NumberBadge>2</NumberBadge>
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#" current>
                 <IconArchive />
-                Lopende zaken
+                Mijn zaken
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>
@@ -129,7 +136,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconUser />
-                Gegevens
+                Mijn gegevens
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving.stories.tsx
@@ -21,6 +21,7 @@ import {
   IconHome,
   IconInbox,
   IconLayoutGrid,
+  IconListCheck,
   IconParking,
   IconUser,
 } from '@tabler/icons-react';
@@ -76,7 +77,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
         <SideNavigationBase>
           <SideNavigationList>
             <SideNavigationItem>
-              <SideNavigationLink href="/#" current>
+              <SideNavigationLink href="/#">
                 <IconLayoutGrid />
                 Overzicht
               </SideNavigationLink>
@@ -85,14 +86,20 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
           <SideNavigationList>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
-                <IconInbox />
-                Berichten<NumberBadge>2</NumberBadge>
+                <IconListCheck />
+                Mijn taken
               </SideNavigationLink>
             </SideNavigationItem>
             <SideNavigationItem>
               <SideNavigationLink href="/#">
+                <IconInbox />
+                Mijn berichten <NumberBadge>2</NumberBadge>
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#" current>
                 <IconArchive />
-                Lopende zaken
+                Mijn zaken
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>
@@ -126,7 +133,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href="/#">
                 <IconUser />
-                Gegevens
+                Mijn gegevens
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>


### PR DESCRIPTION
## In deze PR

* Correct `current` on Side Navigation links
* Storybook Side Navigation labels match Figma labels

## Related issue

Closes issue #254 