### PR TITLE
Feat/mijnzaken template 10+view

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -32,6 +32,7 @@
     "@gemeente-denhaag/process-steps": "4.2.3",
     "@gemeente-denhaag/side-navigation": "4.0.3",
     "@gemeente-denhaag/tab": "3.1.1",
+    "@nl-design-system-candidate/button-react": "1.1.0",
     "@nl-design-system-candidate/heading-react": "1.1.7",
     "@nl-design-system-candidate/link-react": "1.1.8",
     "@nl-design-system-candidate/number-badge-react": "1.3.2",

--- a/packages/storybook/src/components/layout.css
+++ b/packages/storybook/src/components/layout.css
@@ -41,6 +41,20 @@
   display: none;
 }
 
+.todo-visually-hidden {
+  block-size: 1px;
+  border: 0;
+  clip-path: inset(50%);
+  inline-size: 1px;
+  margin-block: -1px;
+  margin-inline: -1px;
+  overflow: hidden;
+  padding-block: 0;
+  padding-inline: 0;
+  position: absolute;
+  white-space: nowrap;
+}
+
 .todo-address {
   font-style: inherit;
   margin-block: 0;
@@ -70,6 +84,29 @@
   padding-inline-start: var(--todo-skip-link-focus-padding-inline-start);
 }
 
+.todo-search-bar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.todo-search-bar__form {
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  gap: 0.5rem;
+  max-inline-size: 600px;
+}
+
+.todo-search-bar__textbox {
+  flex-grow: 1;
+}
+
+.todo-search-bar__button {
+  flex-shrink: 0;
+}
+
 .denhaag-side-navigation__link:focus-visible {
   background-color: var(--todo-link-focus-background-color);
   color: var(--todo-link-focus-color);
@@ -95,6 +132,7 @@
   display: inline-flex;
 }
 
+.todo-button:focus-visible,
 .todo-link:focus-visible,
 .todo-link--with-icon:focus-visible,
 .todo-link--list-item:focus-visible {
@@ -166,5 +204,9 @@
 
   .todo-breadcrumb--desktop {
     display: block;
+  }
+
+  .todo-search-bar {
+    flex-wrap: nowrap;
   }
 }

--- a/packages/storybook/src/components/layout.css
+++ b/packages/storybook/src/components/layout.css
@@ -96,7 +96,7 @@
   display: flex;
   flex-grow: 1;
   gap: 0.5rem;
-  max-inline-size: 600px;
+  max-inline-size: 490px;
 }
 
 .todo-search-bar__textbox {

--- a/packages/storybook/src/components/template-navigation/mijnOmgevingPaths.ts
+++ b/packages/storybook/src/components/template-navigation/mijnOmgevingPaths.ts
@@ -4,7 +4,8 @@ export const storybookPaths = {
   taken: '?path=/story/mijn-omgeving-taken--default',
   berichtenOverzicht: '?path=/story/mijn-omgeving-berichten-overzicht--default',
   berichtDetail: '?path=/story/mijn-omgeving-mijnberichten-detailpagina--default',
-  zakenOverzicht: '?path=/story/mijn-omgeving-mijnzaken-overzicht--default',
+  zakenOverzicht: '?path=/story/mijn-omgeving-mijnzaken-overzicht-card-view--default',
+  zakenOverzichtTableView: '?path=/story/mijn-omgeving-mijnzaken-overzicht-table-view--default',
   zaakDetail: '?path=/story/mijn-omgeving-mijnzaken-detailpagina--default',
   mijnGegevens: '?path=/story/mijn-profiel-1--default',
 } as const;
@@ -15,6 +16,7 @@ export const websitePaths = {
   berichtenOverzicht: '/mijn-services/website/templates/mijn-omgeving-berichten-overzicht',
   berichtDetail: '/mijn-services/website/templates/mijn-omgeving-berichtdetail',
   zakenOverzicht: '/mijn-services/website/templates/mijn-omgeving-zaken-overzicht',
+  zakenOverzichtTableView: '/mijn-services/website/templates/mijn-omgeving-zaken-overzicht-table-view',
   zaakDetail: '/mijn-services/website/templates/mijn-omgeving-zaakdetail',
   mijnGegevens: '/mijn-services/website/templates/mijn-omgeving-gegevens-overzicht',
 } as const;
@@ -26,6 +28,7 @@ export type MijnOmgevingPaths = {
   berichtenOverzicht: string;
   berichtDetail: string;
   zakenOverzicht: string;
+  zakenOverzichtTableView?: string;
   zaakDetail: string;
   mijnGegevens: string;
 };

--- a/packages/storybook/src/templates/mijn-omgeving-home/MijnOmgevingHome.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-home/MijnOmgevingHome.tsx
@@ -203,7 +203,7 @@ export default function MijnOmgevingHome({
             </section>
             <section>
               <Heading level={2}>Mijn zaken</Heading>
-              <Link className="todo-link" href={paths.zakenOverzicht}>
+              <Link className="todo-link" href={paths.zakenOverzichtTableView}>
                 Bekijk alle zaken (15)
               </Link>
               <div className={'todo-card-layout'}>

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.md
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.md
@@ -3,14 +3,14 @@
 Deze documentatie dient voor de MijnZaken overzichtspagina van een MijnOmgeving pagina. De MijnZaken overzichtspagina toont de openstaande en gesloten zaken van een gebruiker.
 Afhankelijk van het aantal zaken wordt een andere weergave getoond:
 
-- **Tot en met 10 zaken** → Card view
+- **Minder dan 10 zaken** → Card view
 - **Meer dan 10 zaken** → Table view
 
-## Card view
+## Minder dan 10 zaken (Card view)
 
 De card view is bedoeld voor gebruikers met een beperkt aantal zaken. Elke zaak wordt weergegeven als een kaart met de zaaktitel en het zaaknummer. Open en gesloten zaken zijn gescheiden via tabs.
 
-## Table view
+## Meer dan 10 zaken (Table view)
 
 De table view is bedoeld voor gebruikers met meer dan 10 zaken. De zaken worden weergegeven in een tabel met zoek- en filtermogelijkheden en paginering.
 

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.md
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.md
@@ -1,0 +1,29 @@
+# MijnOmgeving - MijnZaken Overzicht
+
+Deze documentatie dient voor de MijnZaken overzichtspagina van een MijnOmgeving pagina. De MijnZaken overzichtspagina toont de openstaande en gesloten zaken van een gebruiker.
+Afhankelijk van het aantal zaken wordt een andere weergave getoond:
+
+- **Tot en met 10 zaken** → Card view
+- **Meer dan 10 zaken** → Table view
+
+## Card view
+
+De card view is bedoeld voor gebruikers met een beperkt aantal zaken. Elke zaak wordt weergegeven als een kaart met de zaaktitel en het zaaknummer. Open en gesloten zaken zijn gescheiden via tabs.
+
+## Table view
+
+De table view is bedoeld voor gebruikers met meer dan 10 zaken. De zaken worden weergegeven in een tabel met zoek- en filtermogelijkheden en paginering.
+
+## Github Discussions
+
+Keuzes, relevante onderzoeken en linkjes naar Figma worden vastgelegd in Github Discussions.
+Voor Mijn Omgevingen zijn er bij NL Design System [meerdere discussies](https://github.com/orgs/nl-design-system/discussions/categories/mijn-omgevingen) waar leden van de community feedback achter kunnen laten.
+Hierdoor hebben we alle kennis gevangen op een plek, en kunnen we gezamenlijk verder bouwen aan één overheidsbeleving.
+
+### Relevante discussies voor MijnZaken Overzicht
+
+- [Discussion MijnZaken](https://github.com/orgs/nl-design-system/discussions/394)
+
+## Links
+
+- [Figma ontwerp](https://www.figma.com/design/pB5d6RlVSa1B088Xpm1sSo/MijnServices---Templates?node-id=5488-3723&p=f&t=WgLEQ9wGEkFoJJvb-0)

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.mdx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.mdx
@@ -1,0 +1,10 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as CardViewStory from './mijn-omgeving-zaken-overzicht-card-view/mijn-omgeving-zaken-overzicht-card-view.stories.tsx';
+import * as TableViewStory from './mijn-omgeving-zaken-overzicht-table-view/mijn-omgeving-zaken-overzicht-table-view.stories.tsx';
+
+<Meta title="Templates/MijnOmgeving/MijnZaken/Documentatie" />
+
+## Example
+
+<Canvas of={CardViewStory.Default} />
+<Canvas of={TableViewStory.Default} />

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.mdx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.mdx
@@ -7,10 +7,10 @@ import * as TableViewStory from './mijn-omgeving-zaken-overzicht-table-view/mijn
 
 <Markdown>{markdown}</Markdown>
 
-## Example Card View
+## Example "minder dan 10 zaken" (Card View)
 
 <Canvas of={CardViewStory.Default} />
 
-## Example Table View
+## Example "meer dan 10 zaken" (Table View)
 
 <Canvas of={TableViewStory.Default} />

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.mdx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/documentation.mdx
@@ -1,10 +1,16 @@
-import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { Canvas, Markdown, Meta } from '@storybook/addon-docs/blocks';
+import markdown from './documentation.md?raw';
 import * as CardViewStory from './mijn-omgeving-zaken-overzicht-card-view/mijn-omgeving-zaken-overzicht-card-view.stories.tsx';
 import * as TableViewStory from './mijn-omgeving-zaken-overzicht-table-view/mijn-omgeving-zaken-overzicht-table-view.stories.tsx';
 
 <Meta title="Templates/MijnOmgeving/MijnZaken/Documentatie" />
 
-## Example
+<Markdown>{markdown}</Markdown>
+
+## Example Card View
 
 <Canvas of={CardViewStory.Default} />
+
+## Example Table View
+
 <Canvas of={TableViewStory.Default} />

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView.tsx
@@ -14,7 +14,7 @@ import { Link } from '@nl-design-system-candidate/link-react/css';
 import { NumberBadge } from '@nl-design-system-candidate/number-badge-react';
 import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/theme.css';
 import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
-import '../../themes/index.scss';
+import '../../../themes/index.scss';
 import {
   IconArchive,
   IconBuildingCommunity,
@@ -35,10 +35,10 @@ import {
   Icon,
 } from '@utrecht/component-library-react/dist/css-module';
 import { ReactElement, useEffect, useState } from 'react';
-import { Layout } from '../../components/Layout';
-import { MijnOmgevingPaths } from '../../components/template-navigation/mijnOmgevingPaths';
+import { Layout } from '../../../components/Layout';
+import { MijnOmgevingPaths } from '../../../components/template-navigation/mijnOmgevingPaths';
 
-export default function MijnOmgevingZakenOverzicht({
+export default function MijnOmgevingZakenOverzichtCardView({
   logo,
   footerLogo,
   paths,

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView.tsx
@@ -171,6 +171,22 @@ export default function MijnOmgevingZakenOverzichtCardView({
                           context={'ZK-29124'}
                         />
                         <CaseCard title={'Aanvraag parkeervergunning'} href={paths.zaakDetail} context={'ZK-02599'} />
+                        <CaseCard title={'Melding openbare ruimte'} href={paths.zaakDetail} context={'ZK-02612'} />
+                        <CaseCard title={'Aanvraag woningaanpassing'} href={paths.zaakDetail} context={'ZK-02724'} />
+                        <CaseCard title={'Aanvraag bijzondere bijstand'} href={paths.zaakDetail} context={'ZK-02724'} />
+                        <CaseCard
+                          title={'Aanvraag uittreksel basisregistratie personen'}
+                          href={paths.zaakDetail}
+                          context={'ZK-02724'}
+                        />
+                        <CaseCard title={'Aanvraag naamsbepaling'} href={paths.zaakDetail} context={'ZK-02875'} />
+                        <CaseCard title={'Bezwaar bestemmingsplan'} href={paths.zaakDetail} context={'ZK-02973'} />
+                        <CaseCard title={'Melding overlast buren'} href={paths.zaakDetail} context={'ZK-03001'} />
+                        <CaseCard
+                          title={'Aanvraag gehandicaptenparkeerkaat'}
+                          href={paths.zaakDetail}
+                          context={'ZK-03154'}
+                        />
                       </div>
                     ),
                   },

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/mijn-omgeving-zaken-overzicht-card-view.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/mijn-omgeving-zaken-overzicht-card-view.stories.tsx
@@ -1,20 +1,20 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import MijnOmgevingZakenOverzicht from './MijnOmgevingZakenOverzicht';
-import { DenHaagLogo, PageHeaderLogo, VoorbeeldFooterLogo } from '../../components/Logo';
-import { storybookPaths } from '../../components/template-navigation/mijnOmgevingPaths';
+import MijnOmgevingZakenOverzichtCardView from './MijnOmgevingZakenOverzichtCardView';
+import { DenHaagLogo, PageHeaderLogo, VoorbeeldFooterLogo } from '../../../components/Logo';
+import { storybookPaths } from '../../../components/template-navigation/mijnOmgevingPaths';
 
 const meta = {
-  title: 'Templates/MijnOmgeving/MijnZaken/Overzicht',
-  component: MijnOmgevingZakenOverzicht,
+  title: 'Templates/MijnOmgeving/MijnZaken/Overzicht/CardView',
+  component: MijnOmgevingZakenOverzichtCardView,
   globals: {
     dir: 'ltr',
     lang: 'nl',
   },
-  id: 'mijn-omgeving-mijnzaken-overzicht',
+  id: 'mijn-omgeving-mijnzaken-overzicht-card-view',
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof MijnOmgevingZakenOverzicht>;
+} satisfies Meta<typeof MijnOmgevingZakenOverzichtCardView>;
 
 export default meta;
 

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
@@ -165,7 +165,7 @@ export default function MijnOmgevingZakenOverzichtTableView({
 
               <div className="todo-search-bar">
                 <div className="todo-search-bar__form" role="search">
-                  <label htmlFor="zaken-zoeken" className="visually-hidden">
+                  <label htmlFor="zaken-zoeken" className="todo-visually-hidden">
                     Zoeken in mijn zaken
                   </label>
                   <Textbox className="todo-search-bar__textbox" id="zaken-zoeken" placeholder="Zoeken..."></Textbox>

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
@@ -7,15 +7,18 @@ import {
   SideNavigationLink,
   SideNavigationList,
 } from '@gemeente-denhaag/side-navigation';
+import { Button } from '@nl-design-system-candidate/button-react/css';
 import { Heading } from '@nl-design-system-candidate/heading-react/css';
 import { Link } from '@nl-design-system-candidate/link-react/css';
 import { NumberBadge } from '@nl-design-system-candidate/number-badge-react';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/theme.css';
 import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
 import '../../../themes/index.scss';
 import {
   IconArchive,
   IconBuildingCommunity,
+  IconCalendarEvent,
   IconChevronLeft,
   IconChevronRight,
   IconCurrencyEuro,
@@ -31,6 +34,13 @@ import {
   BreadcrumbNavLink,
   BreadcrumbNavSeparator,
   Icon,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Textbox,
 } from '@utrecht/component-library-react/dist/css-module';
 import { ReactElement } from 'react';
 import { Layout } from '../../../components/Layout';
@@ -148,7 +158,113 @@ export default function MijnOmgevingZakenOverzichtTableView({
         <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
           <main id="main">
             <section>
-              <Heading level={1}>Mijn Zaken</Heading>
+              <Heading level={1} id="mijn-zaken-overzicht-heading">
+                Mijn Zaken
+              </Heading>
+              <Textbox></Textbox>
+              <Button>Zoeken</Button>
+              <Button>
+                <Icon>
+                  <IconCalendarEvent />
+                </Icon>
+                Filter
+              </Button>
+              <Paragraph>89 zaken</Paragraph>
+              <Table aria-labelledby="mijn-zaken-overzicht-heading">
+                <TableHeader>
+                  <TableHeaderCell scope="col">Naam</TableHeaderCell>
+                  <TableHeaderCell scope="col">Datum aanvraag</TableHeaderCell>
+                  <TableHeaderCell scope="col">Open of gesloten</TableHeaderCell>
+                </TableHeader>
+
+                <TableBody>
+                  <TableRow>
+                    <TableCell>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Aanvraag laadpaal
+                      </Link>
+                    </TableCell>
+                    <TableCell>16-03-2025</TableCell>
+                    <TableCell>Open</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Aanvraag subsidie geluidsisolatie
+                      </Link>
+                    </TableCell>
+                    <TableCell>14-01-2025</TableCell>
+                    <TableCell>Open</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Aanvraag parkeervergunning
+                      </Link>
+                    </TableCell>
+                    <TableCell>13-06-2024</TableCell>
+                    <TableCell>Open</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Nog een zaak
+                      </Link>
+                    </TableCell>
+                    <TableCell>13-06-2024</TableCell>
+                    <TableCell>Gesloten</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Nog een zaak
+                      </Link>
+                    </TableCell>
+                    <TableCell>13-06-2024</TableCell>
+                    <TableCell>Gesloten</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link href={paths.zaakDetail}>Nog een zaak</Link>
+                    </TableCell>
+                    <TableCell>13-06-2024</TableCell>
+                    <TableCell>Gesloten</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Nog een zaak
+                      </Link>
+                    </TableCell>
+                    <TableCell>13-06-2024</TableCell>
+                    <TableCell>Gesloten</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link href={paths.zaakDetail}>Nog een zaak</Link>
+                    </TableCell>
+                    <TableCell>13-06-2024</TableCell>
+                    <TableCell>Gesloten</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Nog een zaak
+                      </Link>
+                    </TableCell>
+                    <TableCell>13-06-2024</TableCell>
+                    <TableCell>Gesloten</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
             </section>
           </main>
         </Grid.Cell>

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
@@ -1,0 +1,158 @@
+'use client';
+import '@amsterdam/design-system-css/dist/grid/grid.css';
+import { Grid } from '@amsterdam/design-system-react';
+import {
+  SideNavigationBase,
+  SideNavigationItem,
+  SideNavigationLink,
+  SideNavigationList,
+} from '@gemeente-denhaag/side-navigation';
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
+import { Link } from '@nl-design-system-candidate/link-react/css';
+import { NumberBadge } from '@nl-design-system-candidate/number-badge-react';
+import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/theme.css';
+import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
+import '../../../themes/index.scss';
+import {
+  IconArchive,
+  IconBuildingCommunity,
+  IconChevronLeft,
+  IconChevronRight,
+  IconCurrencyEuro,
+  IconHome,
+  IconInbox,
+  IconLayoutGrid,
+  IconListCheck,
+  IconParking,
+  IconUser,
+} from '@tabler/icons-react';
+import {
+  BreadcrumbNav,
+  BreadcrumbNavLink,
+  BreadcrumbNavSeparator,
+  Icon,
+} from '@utrecht/component-library-react/dist/css-module';
+import { ReactElement } from 'react';
+import { Layout } from '../../../components/Layout';
+import { MijnOmgevingPaths } from '../../../components/template-navigation/mijnOmgevingPaths';
+
+export default function MijnOmgevingZakenOverzichtTableView({
+  logo,
+  footerLogo,
+  paths,
+}: {
+  logo: ReactElement;
+  footerLogo?: ReactElement;
+  paths: MijnOmgevingPaths;
+}) {
+  return (
+    <Layout logo={logo} footerLogo={footerLogo}>
+      <Grid paddingTop={'x-large'}>
+        <Grid.Cell span={{ narrow: 3, medium: 6, wide: 12 }}>
+          <Link href={paths.overzicht} className="todo-breadcrumb--mobile">
+            <Icon>
+              <IconChevronLeft />
+            </Icon>
+            Gemeente Voorbeeld
+          </Link>
+
+          <BreadcrumbNav aria-labelledby="hidden-breadcrumb-header" className="todo-breadcrumb--desktop">
+            <h2 id="hidden-breadcrumb-header" hidden>
+              Kruimelpad
+            </h2>
+            <BreadcrumbNavLink href={paths.overzicht}>Home</BreadcrumbNavLink>
+            <BreadcrumbNavSeparator>
+              <Icon>
+                <IconChevronRight />
+              </Icon>
+            </BreadcrumbNavSeparator>
+            <BreadcrumbNavLink href={paths.overzicht}>Gemeente Voorbeeld</BreadcrumbNavLink>
+            <BreadcrumbNavSeparator>
+              <Icon>
+                <IconChevronRight />
+              </Icon>
+            </BreadcrumbNavSeparator>
+            <BreadcrumbNavLink href={paths.zakenOverzicht} disabled current>
+              Mijn zaken
+            </BreadcrumbNavLink>
+          </BreadcrumbNav>
+        </Grid.Cell>
+
+        <Grid.Cell span={3} className={'todo-grid-cell--hide-on-medium'}>
+          <SideNavigationBase>
+            <SideNavigationList>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.overzicht}>
+                  <IconLayoutGrid />
+                  Overzicht
+                </SideNavigationLink>
+              </SideNavigationItem>
+            </SideNavigationList>
+            <SideNavigationList>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.taken}>
+                  <IconListCheck />
+                  Mijn taken
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.berichtenOverzicht}>
+                  <IconInbox />
+                  Mijn berichten <NumberBadge>2</NumberBadge>
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.zakenOverzicht} current>
+                  <IconArchive />
+                  Mijn zaken
+                </SideNavigationLink>
+              </SideNavigationItem>
+            </SideNavigationList>
+            <SideNavigationList>
+              <SideNavigationItem>
+                <SideNavigationLink href={'/#'}>
+                  <IconCurrencyEuro />
+                  Belastingzaken
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href={'/#'}>
+                  <IconHome />
+                  WOZ
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href={'/#'}>
+                  <IconParking />
+                  Parkeren
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href={'/#'}>
+                  <IconBuildingCommunity />
+                  Erfpacht
+                </SideNavigationLink>
+              </SideNavigationItem>
+            </SideNavigationList>
+            <SideNavigationList>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.mijnGegevens}>
+                  <IconUser />
+                  Mijn gegevens
+                </SideNavigationLink>
+              </SideNavigationItem>
+            </SideNavigationList>
+          </SideNavigationBase>
+        </Grid.Cell>
+
+        <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
+          <main id="main">
+            <section>
+              <Heading level={1}>Mijn Zaken</Heading>
+            </section>
+          </main>
+        </Grid.Cell>
+      </Grid>
+    </Layout>
+  );
+}

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
@@ -42,6 +42,7 @@ import {
   TableRow,
   Textbox,
 } from '@utrecht/component-library-react/dist/css-module';
+import { UtrechtPagination } from '@utrecht/web-component-library-react';
 import { ReactElement } from 'react';
 import { Layout } from '../../../components/Layout';
 import { MijnOmgevingPaths } from '../../../components/template-navigation/mijnOmgevingPaths';
@@ -161,14 +162,22 @@ export default function MijnOmgevingZakenOverzichtTableView({
               <Heading level={1} id="mijn-zaken-overzicht-heading">
                 Mijn Zaken
               </Heading>
-              <Textbox></Textbox>
-              <Button>Zoeken</Button>
-              <Button>
-                <Icon>
-                  <IconCalendarEvent />
-                </Icon>
-                Filter
-              </Button>
+
+              <div className="todo-search-bar">
+                <div className="todo-search-bar__form" role="search">
+                  <label htmlFor="zaken-zoeken" className="visually-hidden">
+                    Zoeken in mijn zaken
+                  </label>
+                  <Textbox className="todo-search-bar__textbox" id="zaken-zoeken" placeholder="Zoeken..."></Textbox>
+                  <Button className="todo-button todo-search-bar__button" type="submit" purpose="secondary">
+                    Zoeken
+                  </Button>
+                </div>
+                <Button iconStart={<IconCalendarEvent />} className="todo-button" purpose="subtle">
+                  Filter
+                </Button>
+              </div>
+
               <Paragraph>89 zaken</Paragraph>
               <Table aria-labelledby="mijn-zaken-overzicht-heading">
                 <TableHeader>
@@ -230,7 +239,9 @@ export default function MijnOmgevingZakenOverzichtTableView({
 
                   <TableRow>
                     <TableCell>
-                      <Link href={paths.zaakDetail}>Nog een zaak</Link>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Nog een zaak
+                      </Link>
                     </TableCell>
                     <TableCell>13-06-2024</TableCell>
                     <TableCell>Gesloten</TableCell>
@@ -248,7 +259,19 @@ export default function MijnOmgevingZakenOverzichtTableView({
 
                   <TableRow>
                     <TableCell>
-                      <Link href={paths.zaakDetail}>Nog een zaak</Link>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Nog een zaak
+                      </Link>
+                    </TableCell>
+                    <TableCell>13-06-2024</TableCell>
+                    <TableCell>Gesloten</TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell>
+                      <Link className="todo-link" href={paths.zaakDetail}>
+                        Nog een zaak
+                      </Link>
                     </TableCell>
                     <TableCell>13-06-2024</TableCell>
                     <TableCell>Gesloten</TableCell>
@@ -265,6 +288,18 @@ export default function MijnOmgevingZakenOverzichtTableView({
                   </TableRow>
                 </TableBody>
               </Table>
+
+              <UtrechtPagination
+                currentIndex={3}
+                links={JSON.stringify([
+                  { href: '#page1', index: 1 },
+                  { href: '#page2', index: 2 },
+                  { href: '#page3', index: 3, current: true },
+                  { href: '#page4', index: 4 },
+                ])}
+                prev={JSON.stringify({ href: '#page2', index: 2 })}
+                next={JSON.stringify({ href: '#page4', index: 4 })}
+              ></UtrechtPagination>
             </section>
           </main>
         </Grid.Cell>

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/mijn-omgeving-zaken-overzicht-table-view.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/mijn-omgeving-zaken-overzicht-table-view.stories.tsx
@@ -1,0 +1,42 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import MijnOmgevingZakenOverzichtTableView from './MijnOmgevingZakenOverzichtTableView';
+import { DenHaagLogo, PageHeaderLogo, VoorbeeldFooterLogo } from '../../../components/Logo';
+import { storybookPaths } from '../../../components/template-navigation/mijnOmgevingPaths';
+
+const meta = {
+  title: 'Templates/MijnOmgeving/MijnZaken/Overzicht/TableView',
+  component: MijnOmgevingZakenOverzichtTableView,
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+  },
+  id: 'mijn-omgeving-mijnzaken-overzicht-table-view',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof MijnOmgevingZakenOverzichtTableView>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    theme: 'voorbeeld-theme',
+  },
+  args: {
+    logo: <PageHeaderLogo />,
+    footerLogo: <VoorbeeldFooterLogo />,
+    paths: storybookPaths,
+  },
+};
+
+export const DenHaagTheme: Story = {
+  parameters: {
+    theme: 'denhaag-theme',
+  },
+  args: {
+    logo: <DenHaagLogo />,
+    paths: storybookPaths,
+  },
+};

--- a/packages/storybook/src/themes/_denhaag.scss
+++ b/packages/storybook/src/themes/_denhaag.scss
@@ -38,21 +38,38 @@
   --nl-paragraph-margin-block-end: 16px;
   --nl-skip-link-background-color: var(--denhaag-color-ocher-2);
   --nl-skip-link-color: var(--denhaag-color-blue-5);
-  --rhc-dot-badge-color: var(--denhaag-color-red-3);
-  --nl-button-secondary-border-color: var(--denhaag-color-green-4);
-  --nl-button-secondary-color: var(--denhaag-color-green-4);
+  --nl-button-min-block-size: 3rem;
+  --nl-button-secondary-border-color: var(--denhaag-color-green-3);
+  --nl-button-secondary-color: var(--denhaag-color-green-3);
   --nl-button-secondary-hover-background-color: var(--denhaag-color-green-1);
   --nl-button-secondary-hover-color: var(--denhaag-color-green-4);
+  --nl-button-secondary-border-width: var(--denhaag-button-border-width);
   --nl-button-subtle-hover-border-color: transparent;
   --nl-button-subtle-hover-background-color: var(--denhaag-color-green-1);
   --nl-button-subtle-hover-color: var(--denhaag-color-green-4);
-  --nl-button-border-radius: 3px;
+  --nl-button-border-radius: 4px;
   --nl-button-subtle-border-color: transparent;
   --nl-button-subtle-color: var(--denhaag-color-green-3);
-  --nl-button-padding-block-end: 10px;
-  --nl-button-padding-block-start: 10px;
-  --nl-button-padding-inline-end: 16px;
-  --nl-button-padding-inline-start: 16px;
+  --nl-button-padding-block-end: calc(
+    var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block)) - var(
+        --denhaag-button-border-width
+      )
+  );
+  --nl-button-padding-block-start: calc(
+    var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block)) - var(
+        --denhaag-button-border-width
+      )
+  );
+  --nl-button-padding-inline-end: calc(
+    var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline)) - var(
+        --denhaag-button-border-width
+      )
+  );
+  --nl-button-padding-inline-start: calc(
+    var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline)) - var(
+        --denhaag-button-border-width
+      )
+  );
 
   /* Amsterdam component tokens */
   --ams-grid-wide-column-count: 12;

--- a/packages/storybook/src/themes/_denhaag.scss
+++ b/packages/storybook/src/themes/_denhaag.scss
@@ -6,6 +6,26 @@
   --utrecht-alert-column-gap: 16px;
   --utrecht-alert-margin-block-end: 32px;
   --utrecht-pagination-margin-block-start: 24px;
+  --utrecht-pagination-relative-link-hover-background-color: var(--denhaag-color-green-1);
+  --utrecht-pagination-relative-link-color: var(--nl-link-color);
+  --utrecht-pagination-relative-link-text-decoration: underline;
+  --utrecht-pagination-relative-link-border-width: 0.0625rem;
+  --utrecht-pagination-relative-link-border-color: transparent;
+  --utrecht-pagination-relative-link-padding-block-end: 12px;
+  --utrecht-pagination-relative-link-padding-block-start: 12px;
+  --utrecht-pagination-relative-link-padding-inline-end: 16px;
+  --utrecht-pagination-relative-link-padding-inline-start: 16px;
+  --utrecht-pagination-page-link-current-border-color: var(--denhaag-color-green-1);
+  --utrecht-pagination-page-link-current-background-color: var(--denhaag-color-green-1);
+  --utrecht-pagination-page-link-padding-block-end: 12px;
+  --utrecht-pagination-page-link-padding-block-start: 12px;
+  --utrecht-pagination-page-link-padding-inline-end: 16px;
+  --utrecht-pagination-page-link-padding-inline-start: 16px;
+  --utrecht-pagination-page-link-hover-background-color: var(--denhaag-color-green-1);
+  --utrecht-pagination-page-link-color: var(--nl-link-color);
+  --utrecht-pagination-page-link-border-color: transparent;
+  --utrecht-pagination-page-link-border-width: 2px;
+  --utrecht-pagination-page-link-text-decoration: underline;
   --utrecht-spotlight-section-background-color: #e3f3fd;
   --utrecht-spotlight-section-padding-block-end: 20px;
   --utrecht-spotlight-section-padding-block-start: 16px;
@@ -19,6 +39,20 @@
   --nl-skip-link-background-color: var(--denhaag-color-ocher-2);
   --nl-skip-link-color: var(--denhaag-color-blue-5);
   --rhc-dot-badge-color: var(--denhaag-color-red-3);
+  --nl-button-secondary-border-color: var(--denhaag-color-green-4);
+  --nl-button-secondary-color: var(--denhaag-color-green-4);
+  --nl-button-secondary-hover-background-color: var(--denhaag-color-green-1);
+  --nl-button-secondary-hover-color: var(--denhaag-color-green-4);
+  --nl-button-subtle-hover-border-color: transparent;
+  --nl-button-subtle-hover-background-color: var(--denhaag-color-green-1);
+  --nl-button-subtle-hover-color: var(--denhaag-color-green-4);
+  --nl-button-border-radius: 3px;
+  --nl-button-subtle-border-color: transparent;
+  --nl-button-subtle-color: var(--denhaag-color-green-3);
+  --nl-button-padding-block-end: 10px;
+  --nl-button-padding-block-start: 10px;
+  --nl-button-padding-inline-end: 16px;
+  --nl-button-padding-inline-start: 16px;
 
   /* Amsterdam component tokens */
   --ams-grid-wide-column-count: 12;

--- a/packages/website/src/app/templates/mijn-omgeving-zaken-overzicht/page.tsx
+++ b/packages/website/src/app/templates/mijn-omgeving-zaken-overzicht/page.tsx
@@ -1,9 +1,13 @@
 import { PageHeaderLogo, VoorbeeldFooterLogo } from '../../../../../storybook/src/components/Logo';
 import { websitePaths } from '../../../../../storybook/src/components/template-navigation/mijnOmgevingPaths';
-import MijnOmgevingZakenOverzicht from '../../../../../storybook/src/templates/mijn-omgeving-zaken-overzicht/MijnOmgevingZakenOverzicht';
+import MijnOmgevingZakenOverzichtCardView from '../../../../../storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView';
 
 export default function Page() {
   return (
-    <MijnOmgevingZakenOverzicht logo={<PageHeaderLogo />} footerLogo={<VoorbeeldFooterLogo />} paths={websitePaths} />
+    <MijnOmgevingZakenOverzichtCardView
+      logo={<PageHeaderLogo />}
+      footerLogo={<VoorbeeldFooterLogo />}
+      paths={websitePaths}
+    />
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@gemeente-denhaag/tab':
         specifier: 3.1.1
         version: 3.1.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nl-design-system-candidate/button-react':
+        specifier: 1.1.0
+        version: 1.1.0(@babel/runtime@7.29.2)(react@19.2.5)
       '@nl-design-system-candidate/heading-react':
         specifier: 1.1.7
         version: 1.1.7(@babel/runtime@7.29.2)(react@19.2.5)
@@ -1341,6 +1344,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@nl-design-system-candidate/button-react@1.1.0':
+    resolution: {integrity: sha512-Zi2QGpAq6/AWkL0hf9BNcNp8AQUV5yyDcKw7WDBuZ3W0ci/EF46ZfvntTbbBpHX09lYqS6F4Vf7hPGh1BdGxTg==}
+    peerDependencies:
+      '@babel/runtime': ^7
+      react: ^18 || ^19
 
   '@nl-design-system-candidate/heading-react@1.1.7':
     resolution: {integrity: sha512-Gvubqw8jrNj0cX5n8fY/xb/iwilvLpaDQ2aUWcGgh+y38YJDOqvckG32LHtmLTUOW+Q6Zl1g5yZ6zvX/af/UYQ==}
@@ -7943,6 +7952,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.3':
     optional: true
+
+  '@nl-design-system-candidate/button-react@1.1.0(@babel/runtime@7.29.2)(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      clsx: 2.1.1
+      react: 19.2.5
 
   '@nl-design-system-candidate/heading-react@1.1.7(@babel/runtime@7.29.2)(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
## In this PR

* Storybook: splitsen van card (bestaat al) view en table (nieuw) view 
* Storybook: documentatie pagina waarop beide views te zien zijn, uitleg gedrag, link naar GitHub discussion + Figma
* +6 cards toevoegen aan zaken overzicht (card view)(10 totaal kan helpen bij het volgende: table view is nu vanaf 10 zaken, dat zou betekenen dat er 10 cards op de card view staan - is dit een goed idee?)
* tokens toevoegen in voorbeeld & den haag thema
* tijdelijke search styling toevoegen (zodat het er nu even mooier uit ziet maar hier moet nog een duurzame oplossing voor komen)



## Related issue

Closes #386 