### PR TITLE
chore: skip changeset for private packages + fix build on vercel

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "baseBranch": "main"
+  "baseBranch": "main",
+  "privatePackages": false
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm --filter @vng.nl/storybook build",
+  "outputDirectory": "packages/storybook/dist/"
+}


### PR DESCRIPTION
Since private packages are not published to npm, we don't need to run changeset for them.  By not showing them in the changeset list we avoid accidental changesets.

Also fix build on vercel, see https://github.com/nl-design-system/mijn-services/issues/428