### PR TITLE
fix: undo vercel.json delete

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm --filter @vng.nl/storybook build",
+  "outputDirectory": "packages/storybook/dist/"
+}


### PR DESCRIPTION
Accidentally removed @richadr 's vercel.json config addition in my last fix. This puts it back