### PR TITLE
ci: configure dependabot cooldown + fix publish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 1
     groups:
       github-actions:
         applies-to: "version-updates"
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 1
     groups:
       patch-and-minor-dependencies:
         applies-to: "version-updates"

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4


### PR DESCRIPTION
This PR configures the [cooldown](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) for dependabot updates to 1 day.

This is a security measure that gives the ecosystem enough time to flag malicious packages before they reach our codebase.

It is already configured in pnpm and npm-check-updates, but not in dependabot.  Thanks to zizmor for flagging.
