### PR TITLE
Remove 'mijn' from sidenav and headings

### DIFF
--- a/packages/storybook/src/templates/mijn-omgeving-basis/mijn-omgeving-basis.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-basis/mijn-omgeving-basis.stories.tsx
@@ -94,19 +94,19 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href={storybookPaths.taken}>
                 <IconListCheck />
-                Mijn taken
+                Taken
               </SideNavigationLink>
             </SideNavigationItem>
             <SideNavigationItem>
               <SideNavigationLink href={storybookPaths.berichtenOverzicht}>
                 <IconInbox />
-                Mijn berichten <NumberBadge>2</NumberBadge>
+                Berichten <NumberBadge>2</NumberBadge>
               </SideNavigationLink>
             </SideNavigationItem>
             <SideNavigationItem>
               <SideNavigationLink href={storybookPaths.zakenOverzicht}>
                 <IconArchive />
-                Mijn zaken
+                Zaken
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>
@@ -140,7 +140,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href={storybookPaths.mijnGegevens}>
                 <IconUser />
-                Mijn gegevens
+                Gegevens
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-berichtdetail/MijnOmgevingBerichtDetail.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-berichtdetail/MijnOmgevingBerichtDetail.tsx
@@ -70,7 +70,7 @@ export default function MijnOmgevingBerichtDetail({
             <Icon>
               <IconChevronLeft />
             </Icon>
-            Mijn berichten
+            Berichten
           </Link>
 
           <BreadcrumbNav aria-labelledby="hidden-breadcrumb-header" className="todo-breadcrumb--desktop">
@@ -89,7 +89,7 @@ export default function MijnOmgevingBerichtDetail({
                 <IconChevronRight />
               </Icon>
             </BreadcrumbNavSeparator>
-            <BreadcrumbNavLink href={paths.berichtenOverzicht}>Mijn berichten</BreadcrumbNavLink>
+            <BreadcrumbNavLink href={paths.berichtenOverzicht}>Berichten</BreadcrumbNavLink>
             <BreadcrumbNavSeparator>
               <Icon>
                 <IconChevronRight />
@@ -115,19 +115,19 @@ export default function MijnOmgevingBerichtDetail({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.taken}>
                   <IconListCheck />
-                  Mijn taken
+                  Taken
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.berichtenOverzicht} current>
                   <IconInbox />
-                  Mijn berichten <NumberBadge>2</NumberBadge>
+                  Berichten <NumberBadge>2</NumberBadge>
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.zakenOverzicht}>
                   <IconArchive />
-                  Mijn zaken
+                  Zaken
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -161,7 +161,7 @@ export default function MijnOmgevingBerichtDetail({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Mijn gegevens
+                  Gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-berichten-overzicht/MijnOmgevingBerichtenOverzicht.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-berichten-overzicht/MijnOmgevingBerichtenOverzicht.tsx
@@ -125,7 +125,7 @@ export default function MijnOmgevingBerichtenOverzicht({
               </Icon>
             </BreadcrumbNavSeparator>
             <BreadcrumbNavLink href={paths.berichtenOverzicht} disabled current>
-              Mijn berichten
+              Berichten
             </BreadcrumbNavLink>
           </BreadcrumbNav>
         </Grid.Cell>
@@ -144,19 +144,19 @@ export default function MijnOmgevingBerichtenOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.taken}>
                   <IconListCheck />
-                  Mijn taken
+                  Taken
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.berichtenOverzicht} current>
                   <IconInbox />
-                  Mijn berichten <NumberBadge>2</NumberBadge>
+                  Berichten <NumberBadge>2</NumberBadge>
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.zakenOverzicht}>
                   <IconArchive />
-                  Mijn zaken
+                  Zaken
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -190,7 +190,7 @@ export default function MijnOmgevingBerichtenOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Mijn gegevens
+                  Gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -200,7 +200,7 @@ export default function MijnOmgevingBerichtenOverzicht({
         <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
           <main id="main">
             <section>
-              <Heading level={1}>Mijn berichten</Heading>
+              <Heading level={1}>Berichten</Heading>
 
               {messages.map((m) => (
                 <Action key={m.title} link={m.link} dateTime={m.dateTime}>

--- a/packages/storybook/src/templates/mijn-omgeving-gegevens-overzicht/MijnOmgevingGegevensOverzicht.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-gegevens-overzicht/MijnOmgevingGegevensOverzicht.tsx
@@ -81,7 +81,7 @@ export default function MijnOmgevingGegevensOverzicht({
               </Icon>
             </BreadcrumbNavSeparator>
             <BreadcrumbNavLink href={paths.mijnGegevens} disabled current>
-              Mijn gegevens
+              Gegevens
             </BreadcrumbNavLink>
           </BreadcrumbNav>
         </Grid.Cell>
@@ -100,19 +100,19 @@ export default function MijnOmgevingGegevensOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.taken}>
                   <IconListCheck />
-                  Mijn taken
+                  Taken
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.berichtenOverzicht}>
                   <IconInbox />
-                  Mijn berichten <NumberBadge>2</NumberBadge>
+                  Berichten <NumberBadge>2</NumberBadge>
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.zakenOverzicht}>
                   <IconArchive />
-                  Mijn zaken
+                  Zaken
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -146,7 +146,7 @@ export default function MijnOmgevingGegevensOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens} current>
                   <IconUser />
-                  Mijn gegevens
+                  Gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -155,7 +155,7 @@ export default function MijnOmgevingGegevensOverzicht({
 
         <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
           <main id="main">
-            <Heading level={1}>Mijn gegevens</Heading>
+            <Heading level={1}>Gegevens</Heading>
             <Paragraph>
               Op deze pagina ziet u uw persoonlijke gegevens en hoe wij die gebruiken om contact met u te houden.
             </Paragraph>

--- a/packages/storybook/src/templates/mijn-omgeving-home/MijnOmgevingHome.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-home/MijnOmgevingHome.tsx
@@ -111,19 +111,19 @@ export default function MijnOmgevingHome({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.taken}>
                   <IconListCheck />
-                  Mijn taken
+                  Taken
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.berichtenOverzicht}>
                   <IconInbox />
-                  Mijn berichten <NumberBadge>2</NumberBadge>
+                  Berichten <NumberBadge>2</NumberBadge>
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.zakenOverzicht}>
                   <IconArchive />
-                  Mijn zaken
+                  Zaken
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -157,7 +157,7 @@ export default function MijnOmgevingHome({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Mijn gegevens
+                  Gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -180,7 +180,7 @@ export default function MijnOmgevingHome({
               bijvoorbeeld uw rekeningen betalen en zien wanneer uw aanvraag klaar is.
             </Paragraph>
             <section>
-              <Heading level={2}>Wat moet ik regelen</Heading>
+              <Heading level={2}>Taken</Heading>
               <Link className="todo-link" href={paths.taken}>
                 Bekijk alle taken (10)
               </Link>
@@ -209,7 +209,7 @@ export default function MijnOmgevingHome({
               </ActionSingle>
             </section>
             <section>
-              <Heading level={2}>Mijn zaken</Heading>
+              <Heading level={2}>Zaken</Heading>
               <Link className="todo-link" href={paths.zakenOverzichtTableView}>
                 Bekijk alle zaken ({zaakCount})
               </Link>

--- a/packages/storybook/src/templates/mijn-omgeving-taken-overzicht/MijnOmgevingTakenOverzicht.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-taken-overzicht/MijnOmgevingTakenOverzicht.tsx
@@ -86,7 +86,7 @@ export default function MijnOmgevingTakenOverzicht({
               </Icon>
             </BreadcrumbNavSeparator>
             <BreadcrumbNavLink href={paths.taken} disabled current>
-              Mijn taken
+              Taken
             </BreadcrumbNavLink>
           </BreadcrumbNav>
         </Grid.Cell>
@@ -105,19 +105,19 @@ export default function MijnOmgevingTakenOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.taken} current>
                   <IconListCheck />
-                  Mijn taken
+                  Taken
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.berichtenOverzicht}>
                   <IconInbox />
-                  Mijn berichten <NumberBadge>2</NumberBadge>
+                  Berichten <NumberBadge>2</NumberBadge>
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.zakenOverzicht}>
                   <IconArchive />
-                  Mijn zaken
+                  Zaken
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -151,7 +151,7 @@ export default function MijnOmgevingTakenOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Mijn gegevens
+                  Gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -161,7 +161,7 @@ export default function MijnOmgevingTakenOverzicht({
         <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
           <main id="main">
             <section>
-              <Heading level={1}>Mijn taken</Heading>
+              <Heading level={1}>Taken</Heading>
               <ActionSingle
                 className={'todo-action--single'}
                 labels={labels}

--- a/packages/storybook/src/templates/mijn-omgeving-zaakdetail/MijnOmgevingZaakDetail.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaakdetail/MijnOmgevingZaakDetail.tsx
@@ -186,7 +186,7 @@ export default function MijnOmgevingZaakDetail({
             <Icon>
               <IconChevronLeft />
             </Icon>
-            Mijn zaken
+            Zaken
           </Link>
 
           <BreadcrumbNav aria-labelledby="hidden-breadcrumb-header" className="todo-breadcrumb--desktop">
@@ -199,7 +199,7 @@ export default function MijnOmgevingZaakDetail({
                 <IconChevronRight />
               </Icon>
             </BreadcrumbNavSeparator>
-            <BreadcrumbNavLink href={paths.zakenOverzicht}>Mijn zaken</BreadcrumbNavLink>
+            <BreadcrumbNavLink href={paths.zakenOverzicht}>Zaken</BreadcrumbNavLink>
             <BreadcrumbNavSeparator>
               <Icon>
                 <IconChevronRight />
@@ -225,19 +225,19 @@ export default function MijnOmgevingZaakDetail({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.taken}>
                   <IconListCheck />
-                  Mijn taken
+                  Taken
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.berichtenOverzicht}>
                   <IconInbox />
-                  Mijn berichten <NumberBadge>2</NumberBadge>
+                  Berichten <NumberBadge>2</NumberBadge>
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.zakenOverzicht} current>
                   <IconArchive />
-                  Mijn zaken
+                  Zaken
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -271,7 +271,7 @@ export default function MijnOmgevingZaakDetail({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Mijn gegevens
+                  Gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView.tsx
@@ -94,7 +94,7 @@ export default function MijnOmgevingZakenOverzichtCardView({
               </Icon>
             </BreadcrumbNavSeparator>
             <BreadcrumbNavLink href={paths.zakenOverzicht} disabled current>
-              Mijn zaken
+              Zaken
             </BreadcrumbNavLink>
           </BreadcrumbNav>
         </Grid.Cell>
@@ -113,19 +113,19 @@ export default function MijnOmgevingZakenOverzichtCardView({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.taken}>
                   <IconListCheck />
-                  Mijn taken
+                  Taken
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.berichtenOverzicht}>
                   <IconInbox />
-                  Mijn berichten <NumberBadge>2</NumberBadge>
+                  Berichten <NumberBadge>2</NumberBadge>
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.zakenOverzicht} current>
                   <IconArchive />
-                  Mijn zaken
+                  Zaken
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -159,7 +159,7 @@ export default function MijnOmgevingZakenOverzichtCardView({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Mijn gegevens
+                  Gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -169,7 +169,7 @@ export default function MijnOmgevingZakenOverzichtCardView({
         <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
           <main id="main">
             <section>
-              <Heading level={1}>Mijn Zaken</Heading>
+              <Heading level={1}>Zaken</Heading>
               <Tabs
                 key={tabsKey}
                 tabData={[

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
@@ -95,7 +95,7 @@ export default function MijnOmgevingZakenOverzichtTableView({
               </Icon>
             </BreadcrumbNavSeparator>
             <BreadcrumbNavLink href={paths.zakenOverzicht} disabled current>
-              Mijn zaken
+              Zaken
             </BreadcrumbNavLink>
           </BreadcrumbNav>
         </Grid.Cell>
@@ -114,19 +114,19 @@ export default function MijnOmgevingZakenOverzichtTableView({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.taken}>
                   <IconListCheck />
-                  Mijn taken
+                  Taken
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.berichtenOverzicht}>
                   <IconInbox />
-                  Mijn berichten <NumberBadge>2</NumberBadge>
+                  Berichten <NumberBadge>2</NumberBadge>
                 </SideNavigationLink>
               </SideNavigationItem>
               <SideNavigationItem>
                 <SideNavigationLink href={paths.zakenOverzicht} current>
                   <IconArchive />
-                  Mijn zaken
+                  Zaken
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -160,7 +160,7 @@ export default function MijnOmgevingZakenOverzichtTableView({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Mijn gegevens
+                  Gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -171,7 +171,7 @@ export default function MijnOmgevingZakenOverzichtTableView({
           <main id="main">
             <section>
               <Heading level={1} id="mijn-zaken-overzicht-heading">
-                Mijn Zaken
+                Zaken
               </Heading>
 
               <div className="todo-search-bar">


### PR DESCRIPTION
## In this PR 

Removed the word "mijn" from sidenav items and updated headings to match the side nav (as agreed upon during the "Mijn Mijn Mijn" workshop). This ensures a cleaner UI and consistent navigation across the application.

## Related issue

Closes #471 