### PR TITLE
refactor: "gegevens" should remain "mijn gegevens"

### DIFF
--- a/packages/storybook/src/templates/mijn-omgeving-basis/mijn-omgeving-basis.stories.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-basis/mijn-omgeving-basis.stories.tsx
@@ -140,7 +140,7 @@ const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: R
             <SideNavigationItem>
               <SideNavigationLink href={storybookPaths.mijnGegevens}>
                 <IconUser />
-                Gegevens
+                Mijn gegevens
               </SideNavigationLink>
             </SideNavigationItem>
           </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-berichtdetail/MijnOmgevingBerichtDetail.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-berichtdetail/MijnOmgevingBerichtDetail.tsx
@@ -161,7 +161,7 @@ export default function MijnOmgevingBerichtDetail({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Gegevens
+                  Mijn gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-berichten-overzicht/MijnOmgevingBerichtenOverzicht.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-berichten-overzicht/MijnOmgevingBerichtenOverzicht.tsx
@@ -190,7 +190,7 @@ export default function MijnOmgevingBerichtenOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Gegevens
+                  Mijn gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-gegevens-overzicht/MijnOmgevingGegevensOverzicht.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-gegevens-overzicht/MijnOmgevingGegevensOverzicht.tsx
@@ -81,7 +81,7 @@ export default function MijnOmgevingGegevensOverzicht({
               </Icon>
             </BreadcrumbNavSeparator>
             <BreadcrumbNavLink href={paths.mijnGegevens} disabled current>
-              Gegevens
+              Mijn gegevens
             </BreadcrumbNavLink>
           </BreadcrumbNav>
         </Grid.Cell>
@@ -146,7 +146,7 @@ export default function MijnOmgevingGegevensOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens} current>
                   <IconUser />
-                  Gegevens
+                  Mijn gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>
@@ -155,7 +155,7 @@ export default function MijnOmgevingGegevensOverzicht({
 
         <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
           <main id="main">
-            <Heading level={1}>Gegevens</Heading>
+            <Heading level={1}>Mijn gegevens</Heading>
             <Paragraph>
               Op deze pagina ziet u uw persoonlijke gegevens en hoe wij die gebruiken om contact met u te houden.
             </Paragraph>

--- a/packages/storybook/src/templates/mijn-omgeving-home/MijnOmgevingHome.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-home/MijnOmgevingHome.tsx
@@ -157,7 +157,7 @@ export default function MijnOmgevingHome({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Gegevens
+                  Mijn gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-taken-overzicht/MijnOmgevingTakenOverzicht.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-taken-overzicht/MijnOmgevingTakenOverzicht.tsx
@@ -151,7 +151,7 @@ export default function MijnOmgevingTakenOverzicht({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Gegevens
+                  Mijn gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-zaakdetail/MijnOmgevingZaakDetail.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaakdetail/MijnOmgevingZaakDetail.tsx
@@ -271,7 +271,7 @@ export default function MijnOmgevingZaakDetail({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Gegevens
+                  Mijn gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-card-view/MijnOmgevingZakenOverzichtCardView.tsx
@@ -159,7 +159,7 @@ export default function MijnOmgevingZakenOverzichtCardView({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Gegevens
+                  Mijn gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>

--- a/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
+++ b/packages/storybook/src/templates/mijn-omgeving-zaken-overzicht/mijn-omgeving-zaken-overzicht-table-view/MijnOmgevingZakenOverzichtTableView.tsx
@@ -160,7 +160,7 @@ export default function MijnOmgevingZakenOverzichtTableView({
               <SideNavigationItem>
                 <SideNavigationLink href={paths.mijnGegevens}>
                   <IconUser />
-                  Gegevens
+                  Mijn gegevens
                 </SideNavigationLink>
               </SideNavigationItem>
             </SideNavigationList>


### PR DESCRIPTION
## In this PR

At MijnServices check-in (25/06) it has been decided that template should keep using "mijn gegevens" instead of only "gegevens" for now at least. (definite conclusion requires further research)

This PR corrects those changes already made in [this previous PR ](https://github.com/nl-design-system/mijn-services/pull/480) (that removed ALL "mijn" from side nav items). 

## Related issue

Closes #493 