### PR TITLE
feat(MijnPlan): add Takenoverzicht template view

### DIFF
--- a/packages/storybook/src/components/template-navigation/mijnOmgevingPaths.ts
+++ b/packages/storybook/src/components/template-navigation/mijnOmgevingPaths.ts
@@ -4,6 +4,8 @@ export const storybookPaths = {
   taken: '?path=/story/mijn-omgeving-taken--default',
   berichtenOverzicht: '?path=/story/mijn-omgeving-berichten-overzicht--default',
   berichtDetail: '?path=/story/mijn-omgeving-mijnberichten-detailpagina--default',
+  mijnPlanOverzichtOntwikkelplan: '?path=/story/concepts-mijnplan--default',
+  mijnPlanTakenOverzicht: '?path=/story/concepts-mijnplan-taken-overzicht--default',
   zakenOverzicht: '?path=/story/mijn-omgeving-mijnzaken-overzicht-card-view--default',
   zakenOverzichtTableView: '?path=/story/mijn-omgeving-mijnzaken-overzicht-table-view--default',
   zaakDetail: '?path=/story/mijn-omgeving-mijnzaken-detailpagina--default',
@@ -15,6 +17,8 @@ export const websitePaths = {
   taken: '/mijn-services/website/templates/mijn-omgeving-taken-overzicht',
   berichtenOverzicht: '/mijn-services/website/templates/mijn-omgeving-berichten-overzicht',
   berichtDetail: '/mijn-services/website/templates/mijn-omgeving-berichtdetail',
+  mijnPlanOverzichtOntwikkelplan: '/mijn-services/website/templates/mijn-plan-overzicht-ontwikkelplan',
+  mijnPlanTakenOverzicht: '/mijn-services/website/templates/mijn-plan-taken-overzicht',
   zakenOverzicht: '/mijn-services/website/templates/mijn-omgeving-zaken-overzicht',
   zakenOverzichtTableView: '/mijn-services/website/templates/mijn-omgeving-zaken-overzicht-table-view',
   zaakDetail: '/mijn-services/website/templates/mijn-omgeving-zaakdetail',
@@ -27,6 +31,8 @@ export type MijnOmgevingPaths = {
   taken: string;
   berichtenOverzicht: string;
   berichtDetail: string;
+  mijnPlanOverzichtOntwikkelplan: string;
+  mijnPlanTakenOverzicht: string;
   zakenOverzicht: string;
   zakenOverzichtTableView?: string;
   zaakDetail: string;

--- a/packages/storybook/src/concepts/mijn-omgeving-mijn-plan/mijn-omgeving-mijn-plan-takenoverzicht/MijnPlanTakenOverzicht.tsx
+++ b/packages/storybook/src/concepts/mijn-omgeving-mijn-plan/mijn-omgeving-mijn-plan-takenoverzicht/MijnPlanTakenOverzicht.tsx
@@ -1,0 +1,278 @@
+'use client';
+import '@amsterdam/design-system-css/dist/grid/grid.css';
+import { Grid } from '@amsterdam/design-system-react';
+import { ActionSingle } from '@gemeente-denhaag/action';
+import {
+  SideNavigationBase,
+  SideNavigationItem,
+  SideNavigationLink,
+  SideNavigationList,
+} from '@gemeente-denhaag/side-navigation';
+import { Tabs } from '@gemeente-denhaag/tab';
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
+import { Link } from '@nl-design-system-candidate/link-react/css';
+import { NumberBadge } from '@nl-design-system-candidate/number-badge-react';
+import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/theme.css';
+import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
+import '../../../themes/index.scss';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
+import {
+  IconArchive,
+  IconBuildingCommunity,
+  IconChevronLeft,
+  IconChevronRight,
+  IconClipboard,
+  IconCurrencyEuro,
+  IconHome,
+  IconInbox,
+  IconInfoCircle,
+  IconLayoutGrid,
+  IconListCheck,
+  IconParking,
+  IconUser,
+} from '@tabler/icons-react';
+import {
+  Alert,
+  BreadcrumbNav,
+  BreadcrumbNavLink,
+  BreadcrumbNavSeparator,
+  Icon,
+} from '@utrecht/component-library-react/dist/css-module';
+import { ReactElement, useEffect, useState } from 'react';
+import { Layout } from '../../../components/Layout';
+import { MijnOmgevingPaths } from '../../../components/template-navigation/mijnOmgevingPaths';
+
+// TODO: placeholder only — replace once the Taken data model/API is defined.
+// Shape is a guess based on how Taken could be rendered.
+// "now" below is the fixed reference point ("today") for this fixture's date math.
+const now = '2026-07-07T00:00:00.000Z';
+
+const takenFixture = [
+  {
+    id: '1',
+    title: 'Individuele inkomstentoeslag aanvragen',
+    dateTime: '2026-10-10T00:00:00.000Z', // future date
+    completed: false,
+  },
+  {
+    id: '2',
+    title: 'Betaal uw parkeerbon van € 74,90 voor parkeren bij Valeriusplein',
+    dateTime: '2026-07-09T00:00:00.000Z', // 2 days after "now" → falls in the "nog X dagen" window
+    completed: false,
+  },
+  {
+    id: '3',
+    title: 'Verleng uw identiteitskaart',
+    completed: true,
+    dateTime: '2026-12-31T00:00:00.000Z', // completed, but dated in the future relative to "now"
+  },
+  {
+    id: '4',
+    title: 'Nog een afgeronde taak',
+    completed: true,
+    dateTime: '2026-02-04T00:00:00.000Z', // completed, dated in the past relative to "now"
+  },
+];
+
+const labels = {
+  today: 'vandaag',
+  yesterday: 'gisteren',
+  before: 'vóór',
+  approachingDeadline: (daysDifference: number) =>
+    daysDifference === 1 ? `nog ${daysDifference} dag` : `nog ${daysDifference} dagen`,
+};
+
+const formatCompletedDate = (dateTime: string) =>
+  new Intl.DateTimeFormat('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' }).format(new Date(dateTime));
+
+export default function MijnPlanTakenOverzicht({
+  logo,
+  footerLogo,
+  paths,
+}: {
+  logo: ReactElement;
+  footerLogo?: ReactElement;
+  paths: MijnOmgevingPaths;
+}) {
+  const [tabsKey, setTabsKey] = useState(0);
+  const openTaken = takenFixture.filter((taak) => !taak.completed);
+  const afgerondeTaken = takenFixture.filter((taak) => taak.completed);
+
+  /* workaround to force re-render, needs a fix in Den Haag Tabs component */
+  useEffect(() => {
+    setTabsKey(1);
+  }, []);
+
+  return (
+    <Layout logo={logo} footerLogo={footerLogo}>
+      <Grid paddingTop={'x-large'}>
+        <Grid.Cell span={{ narrow: 3, medium: 6, wide: 12 }}>
+          <Link href={paths.overzicht} className="todo-breadcrumb--mobile">
+            <Icon>
+              <IconChevronLeft />
+            </Icon>
+            Home
+          </Link>
+
+          <BreadcrumbNav aria-labelledby="hidden-breadcrumb-header" className="todo-breadcrumb--desktop">
+            <h2 id="hidden-breadcrumb-header" hidden>
+              Kruimelpad
+            </h2>
+            <BreadcrumbNavLink href={paths.overzicht}>Home</BreadcrumbNavLink>
+            <BreadcrumbNavSeparator>
+              <Icon>
+                <IconChevronRight />
+              </Icon>
+            </BreadcrumbNavSeparator>
+            <BreadcrumbNavLink href={paths.mijnPlanTakenOverzicht} disabled current>
+              Taken
+            </BreadcrumbNavLink>
+          </BreadcrumbNav>
+        </Grid.Cell>
+
+        <Grid.Cell span={3} className={'todo-grid-cell--hide-on-medium'}>
+          <SideNavigationBase>
+            <SideNavigationList>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.overzicht}>
+                  <IconLayoutGrid />
+                  Overzicht
+                </SideNavigationLink>
+              </SideNavigationItem>
+            </SideNavigationList>
+            <SideNavigationList>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.mijnPlanTakenOverzicht} current>
+                  <IconListCheck />
+                  Taken <NumberBadge>{openTaken.length}</NumberBadge>
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.berichtenOverzicht}>
+                  <IconInbox />
+                  Berichten
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.mijnPlanOverzichtOntwikkelplan}>
+                  <IconClipboard />
+                  Plannen
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.zakenOverzicht}>
+                  <IconArchive />
+                  Zaken
+                </SideNavigationLink>
+              </SideNavigationItem>
+            </SideNavigationList>
+            <SideNavigationList>
+              <SideNavigationItem>
+                <SideNavigationLink href="/#">
+                  <IconCurrencyEuro />
+                  Belastingzaken
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href="/#">
+                  <IconHome />
+                  WOZ
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href="/#">
+                  <IconParking />
+                  Parkeren
+                </SideNavigationLink>
+              </SideNavigationItem>
+              <SideNavigationItem>
+                <SideNavigationLink href="/#">
+                  <IconBuildingCommunity />
+                  Erfpacht
+                </SideNavigationLink>
+              </SideNavigationItem>
+            </SideNavigationList>
+            <SideNavigationList>
+              <SideNavigationItem>
+                <SideNavigationLink href={paths.mijnGegevens}>
+                  <IconUser />
+                  Mijn gegevens
+                </SideNavigationLink>
+              </SideNavigationItem>
+            </SideNavigationList>
+          </SideNavigationBase>
+        </Grid.Cell>
+
+        <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
+          <main id="main">
+            <Alert type="warning" icon={<IconInfoCircle className="utrecht-icon" />}>
+              <Heading level={1} appearance="level-3">
+                Concept
+              </Heading>
+              <Paragraph>
+                MijnPlan template is nog in ontwikkeling. Het design is vastgesteld, maar de implementatie loopt nog.
+                Gebruik dit nog niet als startpunt voor een gemeente-implementatie.
+              </Paragraph>
+            </Alert>
+            <section>
+              <Heading level={1}>Taken</Heading>
+              <Tabs
+                key={tabsKey}
+                tabData={[
+                  {
+                    // TODO: replace brackets with number-badge when component on Den Haag side has been updated
+                    label: `Open taken (${openTaken.length})`,
+                    panelContent: (
+                      <>
+                        {openTaken.map((taak) => (
+                          <ActionSingle
+                            key={taak.id}
+                            className={'todo-action--single'}
+                            labels={labels}
+                            // TODO: change URL into the Taak detail page later
+                            link={paths.zaakDetail}
+                            now={now}
+                            dateTime={taak.dateTime}
+                            relativeDate
+                            locale="nl-NL"
+                          >
+                            <strong>{taak.title}</strong>
+                          </ActionSingle>
+                        ))}
+                      </>
+                    ),
+                  },
+                  {
+                    // TODO: replace brackets with number-badge when component on Den Haag side has been updated
+                    label: `Afgerond (${afgerondeTaken.length})`,
+                    panelContent: (
+                      <>
+                        {afgerondeTaken.map((taak) => (
+                          <ActionSingle
+                            key={taak.id}
+                            className={'todo-action--single'}
+                            // TODO: change URL into the Taak detail page later
+                            link={paths.zaakDetail}
+                            labels={labels}
+                            // No dateTime here on purpose — ActionDate hardcodes a numeric
+                            // format ("2-10-2026") whenever relativeDate is false, with no
+                            // way to override it via props. Formatting the date ourselves
+                            // and passing it as `details` gets the long format the design
+                            // needs ("2 oktober 2026") without the "vóór" prefix.
+                            details={formatCompletedDate(taak.dateTime)}
+                          >
+                            <strong>{taak.title}</strong>
+                          </ActionSingle>
+                        ))}
+                      </>
+                    ),
+                  },
+                ]}
+              />
+            </section>
+          </main>
+        </Grid.Cell>
+      </Grid>
+    </Layout>
+  );
+}

--- a/packages/storybook/src/concepts/mijn-omgeving-mijn-plan/mijn-omgeving-mijn-plan-takenoverzicht/mijn-plan-takenoverzicht.stories.tsx
+++ b/packages/storybook/src/concepts/mijn-omgeving-mijn-plan/mijn-omgeving-mijn-plan-takenoverzicht/mijn-plan-takenoverzicht.stories.tsx
@@ -1,0 +1,42 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import MijnPlanTakenOverzicht from './MijnPlanTakenOverzicht';
+import { DenHaagLogo, PageHeaderLogo, VoorbeeldFooterLogo } from '../../../components/Logo';
+import { storybookPaths } from '../../../components/template-navigation/mijnOmgevingPaths';
+
+const meta = {
+  title: 'Concepts/MijnPlan/TakenOverzicht',
+  component: MijnPlanTakenOverzicht,
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+  },
+  id: 'concepts-mijnplan-taken-overzicht',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof MijnPlanTakenOverzicht>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    theme: 'voorbeeld-theme',
+  },
+  args: {
+    logo: <PageHeaderLogo />,
+    footerLogo: <VoorbeeldFooterLogo />,
+    paths: storybookPaths,
+  },
+};
+
+export const DenHaagTheme: Story = {
+  parameters: {
+    theme: 'denhaag-theme',
+  },
+  args: {
+    logo: <DenHaagLogo />,
+    paths: storybookPaths,
+  },
+};

--- a/packages/storybook/src/concepts/mijn-omgeving-mijn-plan/mijn-plan.stories.tsx
+++ b/packages/storybook/src/concepts/mijn-omgeving-mijn-plan/mijn-plan.stories.tsx
@@ -1,15 +1,48 @@
+import '@amsterdam/design-system-css/dist/grid/grid.css';
+import { Grid } from '@amsterdam/design-system-react';
+import {
+  SideNavigationBase,
+  SideNavigationItem,
+  SideNavigationLink,
+  SideNavigationList,
+} from '@gemeente-denhaag/side-navigation';
 import { Heading } from '@nl-design-system-candidate/heading-react/css';
+import { Link } from '@nl-design-system-candidate/link-react/css';
+import { NumberBadge } from '@nl-design-system-candidate/number-badge-react';
 import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { IconInfoCircle } from '@tabler/icons-react';
-import { Alert } from '@utrecht/component-library-react/dist/css-module';
 import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/theme.css';
 import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
+import '../../themes/index.scss';
+import {
+  IconArchive,
+  IconBuildingCommunity,
+  IconChevronLeft,
+  IconChevronRight,
+  IconClipboard,
+  IconCurrencyEuro,
+  IconHome,
+  IconInbox,
+  IconInfoCircle,
+  IconLayoutGrid,
+  IconListCheck,
+  IconParking,
+  IconUser,
+} from '@tabler/icons-react';
+import {
+  Alert,
+  BreadcrumbNav,
+  BreadcrumbNavLink,
+  BreadcrumbNavSeparator,
+  Icon,
+} from '@utrecht/component-library-react/dist/css-module';
+import { ReactElement } from 'react';
 import { Layout } from '../../components/Layout';
 import { PageHeaderLogo, VoorbeeldFooterLogo } from '../../components/Logo';
+import { storybookPaths } from '../../components/template-navigation/mijnOmgevingPaths';
 
 const meta = {
-  title: 'Concepts/MijnPlan',
+  title: 'Concepts/MijnPlan/OverzichtOntwikkelplan',
   globals: {
     dir: 'ltr',
     lang: 'nl',
@@ -24,24 +57,126 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const TemplatePage = ({ logo, footerLogo }: { logo: ReactElement; footerLogo?: ReactElement }) => (
+  <Layout logo={logo} footerLogo={footerLogo}>
+    <Grid paddingTop={'x-large'}>
+      <Grid.Cell span={{ narrow: 3, medium: 6, wide: 12 }}>
+        <Link href={'/#'} className="todo-breadcrumb--mobile">
+          <Icon>
+            <IconChevronLeft />
+          </Icon>
+          Home
+        </Link>
+
+        <BreadcrumbNav aria-labelledby="hidden-breadcrumb-header" className="todo-breadcrumb--desktop">
+          <h2 id="hidden-breadcrumb-header" hidden>
+            Kruimelpad
+          </h2>
+          <BreadcrumbNavLink href={'/#'}>Home</BreadcrumbNavLink>
+          <BreadcrumbNavSeparator>
+            <Icon>
+              <IconChevronRight />
+            </Icon>
+          </BreadcrumbNavSeparator>
+          <BreadcrumbNavLink href={'/#'} current disabled>
+            Gemeente Voorbeeld
+          </BreadcrumbNavLink>
+        </BreadcrumbNav>
+      </Grid.Cell>
+
+      <Grid.Cell span={3} className={'todo-grid-cell--hide-on-medium'}>
+        <SideNavigationBase>
+          <SideNavigationList>
+            <SideNavigationItem>
+              <SideNavigationLink href={storybookPaths.overzicht}>
+                <IconLayoutGrid />
+                Overzicht
+              </SideNavigationLink>
+            </SideNavigationItem>
+          </SideNavigationList>
+          <SideNavigationList>
+            <SideNavigationItem>
+              <SideNavigationLink href={storybookPaths.mijnPlanTakenOverzicht}>
+                <IconListCheck />
+                Taken <NumberBadge>5</NumberBadge>
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href={storybookPaths.berichtenOverzicht}>
+                <IconInbox />
+                Berichten
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href={storybookPaths.mijnPlanOverzichtOntwikkelplan} current>
+                <IconClipboard />
+                Plannen
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href={storybookPaths.zakenOverzicht}>
+                <IconArchive />
+                Zaken
+              </SideNavigationLink>
+            </SideNavigationItem>
+          </SideNavigationList>
+          <SideNavigationList>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#">
+                <IconCurrencyEuro />
+                Belastingzaken
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#">
+                <IconHome />
+                WOZ
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#">
+                <IconParking />
+                Parkeren
+              </SideNavigationLink>
+            </SideNavigationItem>
+            <SideNavigationItem>
+              <SideNavigationLink href="/#">
+                <IconBuildingCommunity />
+                Erfpacht
+              </SideNavigationLink>
+            </SideNavigationItem>
+          </SideNavigationList>
+          <SideNavigationList>
+            <SideNavigationItem>
+              <SideNavigationLink href={storybookPaths.mijnGegevens}>
+                <IconUser />
+                Mijn gegevens
+              </SideNavigationLink>
+            </SideNavigationItem>
+          </SideNavigationList>
+        </SideNavigationBase>
+      </Grid.Cell>
+
+      <Grid.Cell span={{ narrow: 3, medium: 6, wide: 9 }}>
+        <main id="main">
+          <Alert type="warning" icon={<IconInfoCircle className="utrecht-icon" />}>
+            <Heading level={1} appearance="level-3">
+              Concept
+            </Heading>
+            <Paragraph>
+              MijnPlan template is nog in ontwikkeling. Het design is vastgesteld, maar de implementatie loopt nog.
+              Gebruik dit nog niet als startpunt voor een gemeente-implementatie.
+            </Paragraph>
+          </Alert>
+        </main>
+      </Grid.Cell>
+    </Grid>
+  </Layout>
+);
+
 export const Default: Story = {
   parameters: {
     theme: 'voorbeeld-theme',
   },
-  render: () => (
-    <Layout logo={<PageHeaderLogo />} footerLogo={<VoorbeeldFooterLogo />}>
-      <main id="main">
-        <Alert type="warning" icon={<IconInfoCircle className="utrecht-icon" />}>
-          <Heading level={1} appearance="level-3">
-            Concept
-          </Heading>
-          <Paragraph>
-            MijnPlan template is nog in ontwikkeling. Het design is vastgesteld, maar de implementatie loopt nog.
-            Gebruik dit nog niet als startpunt voor een gemeente-implementatie.
-          </Paragraph>
-        </Alert>
-        {/* TODO: MijnPlan content */}
-      </main>
-    </Layout>
-  ),
+  render: () => <TemplatePage logo={<PageHeaderLogo />} footerLogo={<VoorbeeldFooterLogo />} />,
 };


### PR DESCRIPTION
Refactoring the MijnPlan set-up + adding the Takenoverzicht page

Issue: https://github.com/nl-design-system/mijn-services/issues/509

Note/ questions that need update:

- should 'afgerond' actually show dates? with/without "_vóór_"? 
 ✅ UPDATE: yes to dates, no to 'voor': https://www.figma.com/design/RCHZdQClPESi6PRA2PWmew/MijnServices---Acato?node-id=4251-45645&t=76ppcfxBjHsXxlDM-1
- design doesn't show the number badge (yet?) in the Tabs 
 ✅ UPDATE:  they do need the number badge, new design with states: https://www.figma.com/design/RCHZdQClPESi6PRA2PWmew/MijnServices---Acato?t=VRhkXNZWs8DN4dTV-0
- needs the alert on every page as long as it's a concept?  
✅ UPDATE:  yes
- won't have navigational flow yet, since Taak detailpagina is not in this PR 
📝 ToDo for later when it is out of concept
- Tabs component is currently being changed for containing number-badges in denhaag repo so will need an update later 
📝 ToDo for later, same for 'checked' Actions in Afgerond Tab. 
- should all page templates only have a stories file or be split into separate tsx file?  
✅ UPDATE:  to speed up future refactoring: yes

Design: https://www.figma.com/design/RCHZdQClPESi6PRA2PWmew/MijnServices---Acato?node-id=2601-28690&t=foc5TcsNjDnkbaMS-1