### PR TITLE
chore: configure prettier to format pnpm-workspace.yaml the same as pnpm CLI does

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ vendor/
 
 # Ignore generated files
 .angular/
+.next/
 build/
 coverage/
 dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,5 +16,4 @@ CHANGELOG.md
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
-pnpm-workspace.yaml
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,10 @@
 # Edit this file by hand. Using `pnpm config` reformats the file and removes all comments.
 
 packages:
-  - "packages/*"
+  - 'packages/*'
 
 allowBuilds:
-  "@parcel/watcher": true
+  '@parcel/watcher': true
   esbuild: true
   sharp: true
   unrs-resolver: true
@@ -23,25 +23,25 @@ minimumReleaseAge: 1440
 
 # Make an exception for trusted packages, notably our own
 minimumReleaseAgeExclude:
-  - "@amsterdam/*"
-  - "@gemeente-denhaag/*"
-  - "@gemeente-rotterdam/*"
-  - "@nl-design-system/*"
-  - "@nl-design-system-candidate/*"
-  - "@nl-design-system-community/*"
-  - "@nl-design-system-unstable/*"
-  - "@nl-rvo/*"
-  - "@rijkshuisstijl-community/*"
-  - "@utrecht/*"
+  - '@amsterdam/*'
+  - '@gemeente-denhaag/*'
+  - '@gemeente-rotterdam/*'
+  - '@nl-design-system/*'
+  - '@nl-design-system-candidate/*'
+  - '@nl-design-system-community/*'
+  - '@nl-design-system-unstable/*'
+  - '@nl-rvo/*'
+  - '@rijkshuisstijl-community/*'
+  - '@utrecht/*'
 
 overrides:
-  shell-quote@>=1.1.0 <=1.8.3: ">=1.8.4"
-  tar@<=7.5.18: ">=7.5.19"
+  shell-quote@>=1.1.0 <=1.8.3: '>=1.8.4'
+  tar@<=7.5.18: '>=7.5.19'
 
 # Configure pnpm to save exact version numbers (not including ^ or ~) in package.json. Lock dependencies to specific
 # versions to ensure reproducible installs and prevent automatic upgrades to newer minor or patch releases.
 saveExact: true
-savePrefix: ""
+savePrefix: ''
 
 # Configure pnpm to not fail when there are missing or invalid peer dependencies in the tree.
 strictPeerDependencies: false

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -17,5 +17,12 @@ module.exports = {
         singleQuote: false,
       },
     },
+    {
+      // match pnpm CLI-driven changes behavior
+      files: ['pnpm-workspace.yaml'],
+      options: {
+        singleQuote: true,
+      },
+    },
   ],
 };

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,7 +1,7 @@
 /**
  * @type {import('prettier').Config}
  */
-module.exports = {
+export default {
   printWidth: 120,
   singleQuote: true,
   overrides: [


### PR DESCRIPTION
For YAML files, we use double quotes for strings.  We make an exception for the `pnpm-workspace.yaml` file, because the pnpm CLI uses single quotes.
